### PR TITLE
Bumped base version for GHC 7.8.3

### DIFF
--- a/phash.cabal
+++ b/phash.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:  Data.PHash
   exposed-modules:  Data.PHash.Image
   exposed-modules:  Data.PHash.Types
-  build-depends:    base >= 4.6 && < 4.7
+  build-depends:    base >= 4.6 && < 4.8
   hs-source-dirs:   src
   default-language: Haskell2010
   extra-libraries:  pHash
@@ -31,7 +31,7 @@ test-suite spec
   default-language: Haskell2010
   hs-source-dirs:   src, test
   extra-libraries:  pHash
-  build-depends:    base >= 4.6 && < 4.7
+  build-depends:    base >= 4.6 && < 4.8
   build-depends:    tasty >= 0.7 && < 1.0
   build-depends:    tasty-smallcheck >= 0.2 && < 1.0
   build-depends:    tasty-hunit >= 0.4.1 && < 1.0
@@ -45,7 +45,7 @@ test-suite docs
   hs-source-dirs:   src, test
   extra-libraries:  pHash
   ghc-options:      -threaded
-  build-depends:    base >= 4.6 && < 4.7
+  build-depends:    base >= 4.6 && < 4.8
   build-depends:    doctest >= 0.9.10 && < 1.0
   build-depends:    phash
 


### PR DESCRIPTION
This lets you install the packaged for usage with GHC 7.8.3 (Haskell-Plattform 2014). Tested with Haskell-Plattform on OSX (installed phash with brew install phash).
