### PR TITLE
Increase upper bound on base dependency

### DIFF
--- a/phash.cabal
+++ b/phash.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:  Data.PHash
   exposed-modules:  Data.PHash.Image
   exposed-modules:  Data.PHash.Types
-  build-depends:    base >= 4.6 && < 4.9
+  build-depends:    base >= 4.6 && < 5
   hs-source-dirs:   src
   default-language: Haskell2010
   extra-libraries:  pHash
@@ -43,7 +43,7 @@ test-suite spec
   default-language: Haskell2010
   hs-source-dirs:   src, test
   extra-libraries:  pHash
-  build-depends:    base
+  build-depends:    base >= 4.6 && < 5
   build-depends:    tasty >= 0.7 && < 1.0
   build-depends:    tasty-smallcheck >= 0.2 && < 1.0
   build-depends:    tasty-hunit >= 0.4.1 && < 1.0
@@ -61,7 +61,7 @@ test-suite docs
   hs-source-dirs:   src, test
   extra-libraries:  pHash
   ghc-options:      -threaded
-  build-depends:    base
+  build-depends:    base >= 4.6 && < 5
   build-depends:    doctest >= 0.9.10 && < 1.0
   build-depends:    phash
 


### PR DESCRIPTION
Michael,

This package works just fine with this slightly relaxed upper bound: I've been using it happily with base 4.9.

-Richard
